### PR TITLE
Fix for event listening

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ function createLogStream (api) {
 function createEventStream (api) {
   return createLogStream(api)
   .merge(createDiagStream(api, 'net'))
-  .merge(createDiagStream(api, 'sys'))
+//  .merge(createDiagStream(api, 'sys'))
 }
 
 module.exports = createEventStream


### PR DESCRIPTION
commenting out this line fixes an error, "Error: this operation is not supported on your platform"  (using shitty windows - but same on other platforms)